### PR TITLE
Add fastfetch configuration as a neofetch alternative

### DIFF
--- a/.config/fastfetch/config.jsonc
+++ b/.config/fastfetch/config.jsonc
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://github.com/fastfetch-cli/fastfetch/raw/dev/doc/json_schema.json",
+  "display": {
+    "separator": " ➜ ",
+    "color":{"keys": "cyan"}
+  },
+  "modules": [
+    "title",
+    "separator",
+    { "type": "os","format": "{3} {12}" },
+    {"type": "kernel","format": "{2}", "key": "├ Kernel" },
+    {"type": "uptime", "key": "├ Uptime" },
+    {"type": "packages",   "key": "└ Packages" },
+    {"type": "separator", "string": " " },
+    {"type": "host","format": "{2},{5}" },
+    {"type": "cpu","key": "├ CPU", "temp":true, "showPeCoreCount":true},
+    {"type": "memory","key": "├ Memory"},
+    {"type": "swap", "key": "├ Swap"},
+    {"type": "display", "key": "├ Display"},
+    {"type": "gpu", "key": "└ GPU"},
+    {"type": "separator","string": " "},
+    {"type": "terminal", "key": "Terminal"},
+    {"type": "shell", "key": "├ Shell"},
+    {"type": "wm", "key": "├ WM"},
+    {"type": "weather","location": "pingdingshan","timeout": 10000,"key": "└ Weather"}
+  ],
+  "logo": {
+    "type": "kitty",
+    "source": "/home/maxwell/Pictures/image.png",
+    "width": 40
+  }
+}

--- a/.config/fastfetch/config.jsonc
+++ b/.config/fastfetch/config.jsonc
@@ -12,7 +12,7 @@
     {"type": "uptime", "key": "├ Uptime" },
     {"type": "packages",   "key": "└ Packages" },
     {"type": "separator", "string": " " },
-    {"type": "host","format": "{2},{5}" },
+    {"type": "host","format": "{2} {5}" },
     {"type": "cpu","key": "├ CPU", "temp":true, "showPeCoreCount":true},
     {"type": "memory","key": "├ Memory"},
     {"type": "swap", "key": "├ Swap"},


### PR DESCRIPTION
Since Neofetch has been archived and is no longer maintained, I have added a configuration for Fastfetch as an alternative. Fastfetch is a lightweight tool that displays system information in a similar manner to Neofetch.

Here is a comparison of how it looks: 
![swappy-20240910-144655](https://github.com/user-attachments/assets/a44c7daa-3b43-400e-86e3-b4d01c4da83e)
